### PR TITLE
Refactor iris position into t-number

### DIFF
--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -26,10 +26,11 @@
 '''ARRI camera metadata reader'''
 
 import csv
+import math
+import typing
 from fractions import Fraction
 
 import camdkit.model
-
 
 # https://www.arri.com/resource/blob/31908/14147b455c90a9a35018c0d091350ff3/2021-10-arri-formatsandresolutionsoverview-3-4-data.pdf
 _CAMERA_FAMILY_PIXEL_PITCH_MAP = {
@@ -38,6 +39,11 @@ _CAMERA_FAMILY_PIXEL_PITCH_MAP = {
   ("ALEXALF", 3840) : Fraction(316800, 3840),
   ("ALEXALF", 4448) : Fraction(367000, 4448),
 }
+
+def t_number_from_linear_iris_value(lin_value: int) -> typing.Optional[Fraction]:
+  """Calculate t-number (regular iris values) from linear iris values
+  """
+  return math.pow(2, (lin_value - 1000)/1000/2)
 
 def to_clip(csv_path: str) -> camdkit.model.Clip:
   """Read ARRI camera metadata into a `Clip`. `csv_path` is the path to a CSV
@@ -85,7 +91,7 @@ def to_clip(csv_path: str) -> camdkit.model.Clip:
 
     clip.set_focal_position(tuple(int(float(m["Lens Focus Distance"]) * 1000) for m in csv_data))
 
-    clip.set_iris_position(tuple(Fraction(int(m["Lens Linear Iris"]), 1000) for m in csv_data))
+    clip.set_t_number(tuple(round(t_number_from_linear_iris_value(int(m["Lens Linear Iris"])) * 1000) for m in csv_data))
 
     # TODO: Entrance Pupil Position
     # TODO: Sensor physical dimensions

--- a/src/main/python/camdkit/model.py
+++ b/src/main/python/camdkit/model.py
@@ -74,7 +74,7 @@ class Clip:
     self._white_balance = None
     self._focal_length = tuple()
     self._focal_position = tuple()
-    self._iris_position = tuple()
+    self._t_number = tuple()
     self._entrance_pupil_position = tuple()
     
   #
@@ -170,19 +170,21 @@ class Clip:
     return self._white_balance
 
   #
-  # Iris position
+  # t-number
   #
 
-  def set_iris_position(self, samples: typing.Iterable[numbers.Rational]):
-    iris_position = tuple(samples)
+  def set_t_number(self, samples: typing.Iterable[numbers.Integral]):
+    """T-number of the lens (thousandth)
+    """
+    t_number = tuple(samples)
 
-    if not all(isinstance(s, numbers.Rational) and s > 0 for s in iris_position):
-      raise TypeError("Each iris position sample must be a rational larger than 0.")
+    if not all(isinstance(s, numbers.Integral) and s > 0 for s in t_number):
+      raise TypeError("Each t-number sample must be an integer larger than 0.")
 
-    self._iris_position = iris_position
+    self._t_number = t_number
 
-  def get_iris_position(self) -> typing.Tuple[numbers.Rational]:
-    return self._iris_position
+  def get_t_number(self) -> typing.Tuple[numbers.Integral]:
+    return self._t_number
 
   #
   # Focal length
@@ -246,5 +248,5 @@ class Clip:
       "sensor_physical_dimensions": None if self.get_sensor_physical_dimensions() is None else self.get_sensor_physical_dimensions().serialize(),
       "entrance_pupil_position": tuple(map(str, self.get_entrance_pupil_position())),
       "focal_position": self.get_focal_position(),
-      "iris_position": tuple(map(str, self.get_iris_position())),
+      "t_number": tuple(map(str, self.get_t_number())),
     }

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -93,6 +93,6 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
 
   clip.set_entrance_pupil_position(m.entrance_pupil_position for m in cooke_metadata)
 
-  clip.set_iris_position(Fraction(m.aperture_value, 100) for m in cooke_metadata)
+  clip.set_t_number(m.aperture_value * 10 for m in cooke_metadata)
 
   return clip

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -101,7 +101,7 @@ def find_px_dims(doc: ET.ElementTree) -> typing.Optional[camdkit.model.SensorPix
   except TypeError:
     return None
 
-def f_num_from_frac_stop(frac_stop_str: str) -> typing.Optional[int]:
+def t_number_from_frac_stop(frac_stop_str: str) -> typing.Optional[float]:
 
   m = re.fullmatch("T ([0-9]+)(?: ([0-9]/10))?", frac_stop_str)
 
@@ -113,7 +113,7 @@ def f_num_from_frac_stop(frac_stop_str: str) -> typing.Optional[int]:
   if m.group(2) is not None:
     aperture_value += Fraction(m.group(2))
 
-  return Fraction(round(2**(float(aperture_value) / 2) * 100), 100)
+  return 2**(float(aperture_value) / 2)
 
 def int_or_none(value: typing.Optional[str]) -> typing.Optional[int]:
   return int(value) if value is not None else None
@@ -170,8 +170,8 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
 
   clip.set_focal_position(tuple(round(float(m["Focus Distance (ft)"]) * 12 * 25.4) for m in csv_data))
 
-  # clip.set_entrance_pupil_position(m.entrance_pupil_position for m in cooke_metadata)
+  # TODO: clip.set_entrance_pupil_position()
 
-  clip.set_iris_position(tuple(f_num_from_frac_stop(m["Aperture"]) for m in csv_data))
+  clip.set_t_number(tuple(round(t_number_from_frac_stop(m["Aperture"]) * 1000) for m in csv_data))
 
   return clip

--- a/src/test/python/test_arri_reader.py
+++ b/src/test/python/test_arri_reader.py
@@ -58,5 +58,8 @@ class ARRIReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.get_white_balance(), 3200)
     
-    self.assertEqual(clip.get_iris_position()[0], Fraction(2667, 1000))
+    self.assertEqual(clip.get_t_number()[0], 1782)
+
+  def test_linear_iris_value(self):
+    self.assertEqual(round(camdkit.arri.reader.t_number_from_linear_iris_value(6000) * 1000), 5657)
     

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -134,19 +134,19 @@ class ModelTest(unittest.TestCase):
     self.assertEqual(clip.get_fps(), value)
 
 
-  def test_iris_position(self):
+  def test_t_number(self):
     clip = camdkit.model.Clip()
 
-    self.assertTupleEqual(clip.get_iris_position(), tuple())
+    self.assertTupleEqual(clip.get_t_number(), tuple())
 
     with self.assertRaises(TypeError):
-      clip.set_iris_position([0.7])
+      clip.set_t_number([0.7])
 
-    value = (Fraction(5,7), 7)
+    value = (4000, 8000)
 
-    clip.set_iris_position(value)
+    clip.set_t_number(value)
 
-    self.assertTupleEqual(clip.get_iris_position(), value)
+    self.assertTupleEqual(clip.get_t_number(), value)
 
   def test_focal_length(self):
     clip = camdkit.model.Clip()

--- a/src/test/python/test_red_reader.py
+++ b/src/test/python/test_red_reader.py
@@ -43,7 +43,7 @@ class REDReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.get_entrance_pupil_position()[0], 127)
 
-    self.assertEqual(clip.get_iris_position()[0], Fraction(56, 10))
+    self.assertEqual(clip.get_t_number()[0], 5600)
 
     self.assertEqual(clip.get_fps(), 24)
 

--- a/src/test/python/test_venice_reader.py
+++ b/src/test/python/test_venice_reader.py
@@ -33,12 +33,9 @@ from fractions import Fraction
 class VenicReaderTest(unittest.TestCase):
 
   def test_frac_stop(self):
-    self.assertEqual(
-      camdkit.venice.reader.f_num_from_frac_stop("T 2 3/10"),
-      Fraction(222, 100)
-      )
+    self.assertEqual(round(camdkit.venice.reader.t_number_from_frac_stop("T 2 3/10") * 1000), 2219)
 
-    self.assertEqual(camdkit.venice.reader.f_num_from_frac_stop("T 6"), 8)
+    self.assertEqual(round(camdkit.venice.reader.t_number_from_frac_stop("T 6") * 1000), 8000)
 
   def test_reader(self):
     with open("src/test/resources/venice/D001C005_210716AGM01.xml", "r", encoding="utf-8") as static_file, \
@@ -49,7 +46,7 @@ class VenicReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.get_focal_length()[0], 32)
 
-    self.assertEqual(clip.get_iris_position()[0], Fraction(222, 100))
+    self.assertEqual(clip.get_t_number()[0], 2219)
 
     self.assertEqual(clip.get_fps(), 24)
 


### PR DESCRIPTION
Iris position is replace by t-number in thousandths, i.e. `t-number * 1000`

* ARRI: 6000 (linear iris value) → 5657 (t-number in thousandths)
* Cooke: 144 (Aperture Value) → 1440 (t-number in thousandths)
* Venice: `T 2 3/10` (Aperture) → 2219 (t-number in thousandths)

Closes #18 




