### PR TITLE
Simplify the modification and documentation of metadata parameters

### DIFF
--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -87,7 +87,7 @@ def to_clip(csv_path: str) -> camdkit.model.Clip:
 
     clip.set_focal_position(tuple(int(float(m["Lens Focus Distance"]) * 1000) for m in csv_data))
 
-    clip.set_t_number(tuple(round(t_number_from_linear_iris_value(int(m["Lens Linear Iris"])) * 1000) for m in csv_data))
+    clip.t_number = tuple(round(t_number_from_linear_iris_value(int(m["Lens Linear Iris"])) * 1000) for m in csv_data)
 
     # TODO: Entrance Pupil Position
     # TODO: Sensor physical dimensions

--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -80,12 +80,10 @@ def to_clip(csv_path: str) -> camdkit.model.Clip:
 
     pix_dims = clip.get_active_sensor_pixel_dimensions()
     pixel_pitch = _CAMERA_FAMILY_PIXEL_PITCH_MAP[(csv_data[0]["Camera Family"], pix_dims.width)]
-    clip.set_active_sensor_physical_dimensions(
-      camdkit.model.SensorPhysicalDimensions(
+    clip.active_sensor_physical_dimensions = camdkit.model.IntegerDimensions(
         width=round(pix_dims.width * pixel_pitch),
         height=round(pix_dims.height * pixel_pitch)
       )
-    )
 
     clip.set_focal_length(tuple(int(float(m["Lens Focal Length"]) * 1000) for m in csv_data))
 

--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -63,7 +63,7 @@ def to_clip(csv_path: str) -> camdkit.model.Clip:
 
     clip.set_iso(int(csv_data[0]["Exposure Index ASA"]))
 
-    clip.set_duration(len(csv_data)/Fraction(csv_data[0]["Project FPS"]))
+    clip.duration = len(csv_data)/Fraction(csv_data[0]["Project FPS"])
 
     clip.set_lens_serial_number(csv_data[0]["Lens Serial Number"])
 

--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -67,7 +67,7 @@ def to_clip(csv_path: str) -> camdkit.model.Clip:
 
     clip.set_lens_serial_number(csv_data[0]["Lens Serial Number"])
 
-    clip.set_fps(Fraction(csv_data[0]["Project FPS"]))
+    clip.fps = Fraction(csv_data[0]["Project FPS"])
 
     clip.set_white_balance(int(csv_data[0]["White Balance"]))
 

--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -83,9 +83,9 @@ def to_clip(csv_path: str) -> camdkit.model.Clip:
         height=round(pix_dims.height * pixel_pitch)
       )
 
-    clip.set_focal_length(tuple(int(float(m["Lens Focal Length"]) * 1000) for m in csv_data))
+    clip.focal_length = tuple(int(float(m["Lens Focal Length"]) * 1000) for m in csv_data)
 
-    clip.set_focal_position(tuple(int(float(m["Lens Focus Distance"]) * 1000) for m in csv_data))
+    clip.focal_position = tuple(int(float(m["Lens Focus Distance"]) * 1000) for m in csv_data)
 
     clip.t_number = tuple(round(t_number_from_linear_iris_value(int(m["Lens Linear Iris"])) * 1000) for m in csv_data)
 

--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -71,14 +71,12 @@ def to_clip(csv_path: str) -> camdkit.model.Clip:
 
     clip.set_white_balance(int(csv_data[0]["White Balance"]))
 
-    clip.set_active_sensor_pixel_dimensions(
-      camdkit.model.SensorPixelDimensions(
-        width=int(csv_data[0]["Image Width"]),
-        height=int(csv_data[0]["Image Height"])
-      )
+    clip.active_sensor_pixel_dimensions = camdkit.model.IntegerDimensions(
+      width=int(csv_data[0]["Image Width"]),
+      height=int(csv_data[0]["Image Height"])
     )
 
-    pix_dims = clip.get_active_sensor_pixel_dimensions()
+    pix_dims = clip.active_sensor_pixel_dimensions
     pixel_pitch = _CAMERA_FAMILY_PIXEL_PITCH_MAP[(csv_data[0]["Camera Family"], pix_dims.width)]
     clip.active_sensor_physical_dimensions = camdkit.model.IntegerDimensions(
         width=round(pix_dims.width * pixel_pitch),

--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -61,15 +61,15 @@ def to_clip(csv_path: str) -> camdkit.model.Clip:
 
     assert csv_data[0]["Lens Distance Unit"] == "Meter"
 
-    clip.set_iso(int(csv_data[0]["Exposure Index ASA"]))
+    clip.iso = int(csv_data[0]["Exposure Index ASA"])
 
     clip.duration = len(csv_data)/Fraction(csv_data[0]["Project FPS"])
 
-    clip.set_lens_serial_number(csv_data[0]["Lens Serial Number"])
+    clip.lens_serial_number = csv_data[0]["Lens Serial Number"]
 
     clip.fps = Fraction(csv_data[0]["Project FPS"])
 
-    clip.set_white_balance(int(csv_data[0]["White Balance"]))
+    clip.white_balance = int(csv_data[0]["White Balance"])
 
     clip.active_sensor_pixel_dimensions = camdkit.model.IntegerDimensions(
       width=int(csv_data[0]["Image Width"]),

--- a/src/main/python/camdkit/framework.py
+++ b/src/main/python/camdkit/framework.py
@@ -1,0 +1,68 @@
+import typing
+
+class Parameter:
+  """Metadata parameter base class"""
+  @classmethod
+  def __init_subclass__(cls) -> None:
+    if not hasattr(cls, "canonical_name"):
+      raise TypeError("Parameters must has a canonical_name parameter")
+
+  @staticmethod
+  def validate(value) -> bool:
+    raise NotImplementedError
+
+  @staticmethod
+  def to_json(value: typing.Any) -> typing.Any:
+    raise NotImplementedError
+
+  @staticmethod
+  def from_json(value: typing.Any) -> typing.Any:
+    raise NotImplementedError
+    
+    
+class ParameterContainer:
+  def __init__(self) -> None:
+    self._values = {k: None for k in self._params}
+
+  @classmethod
+  def __init_subclass__(cls) -> None:
+    cls._params = {}
+    for f in dir(cls):
+      desc = getattr(cls, f)
+
+      if not isinstance(desc, Parameter):
+        continue
+
+      cls._params[f] = desc
+
+      def _gen_getter(f):
+        def getter(self):
+          return self._values[f]
+        return getter
+      def _gen_setter(f):
+        def setter(self, value):
+          if not self._params[f].validate(value):
+            raise ValueError
+          self._values[f] = value
+        return setter
+
+      setattr(cls, f, property(_gen_getter(f), _gen_setter(f)))
+
+    def _auto__call__init__(self, *a, **kwargs):
+      for base in cls.__bases__:
+        base.__init__(self, *a, **kwargs)
+      ParameterContainer.__init__(self)
+      cls._saved_init(self, *a, **kwargs)
+    cls._saved_init = cls.__init__
+    cls.__init__ = _auto__call__init__
+
+  def to_json(self) -> dict:
+    obj = {}
+    for k, desc in self._params.items():
+      obj[desc.canonical_name] = desc.to_json(self._values[k])
+    return obj
+
+  def from_json(self, json_dict: dict):
+    for k, v in json_dict:
+      if k in self._params:
+        self._values[k] = self._params[k].from_json(v)

--- a/src/main/python/camdkit/framework.py
+++ b/src/main/python/camdkit/framework.py
@@ -59,10 +59,11 @@ class ParameterContainer:
   def to_json(self) -> dict:
     obj = {}
     for k, desc in self._params.items():
-      obj[desc.canonical_name] = desc.to_json(self._values[k])
+      value = self._values[k]
+      obj[desc.canonical_name] = desc.to_json(self._values[k]) if value is not None else None
     return obj
 
   def from_json(self, json_dict: dict):
-    for k, v in json_dict:
+    for k, v in json_dict.items():
       if k in self._params:
         self._values[k] = self._params[k].from_json(v)

--- a/src/main/python/camdkit/model.py
+++ b/src/main/python/camdkit/model.py
@@ -123,51 +123,70 @@ class FPS(Parameter):
   def from_json(value: typing.Any) -> typing.Any:
     return Fraction(value)
 
+
+class ISO(Parameter):
+  """ISO number as an integer"""
+
+  canonical_name = "iso"
+
+  @staticmethod
+  def validate(value) -> bool:
+    return value is None or (isinstance(value, numbers.Integral) and value > 0)
+
+  @staticmethod
+  def to_json(value: typing.Any) -> typing.Any:
+    return str(value)
+
+  @staticmethod
+  def from_json(value: typing.Any) -> typing.Any:
+    return int(value)
+
+
+class WhiteBalance(Parameter):
+  """White balance of the camera expressed as an integer in units of degrees kelvin."""
+
+  canonical_name = "white_balance"
+
+  @staticmethod
+  def validate(value) -> bool:
+    return value is None or (isinstance(value, numbers.Integral) and value > 0)
+
+  @staticmethod
+  def to_json(value: typing.Any) -> typing.Any:
+    return str(value)
+
+  @staticmethod
+  def from_json(value: typing.Any) -> typing.Any:
+    return int(value)
+
+
+class LensSerialNumber(Parameter):
+  """Unique identifier of the lens"""
+
+  canonical_name = "lens_serial_number"
+
+  @staticmethod
+  def validate(value) -> bool:
+    return value is None or isinstance(value, str)
+
+  @staticmethod
+  def to_json(value: typing.Any) -> typing.Any:
+    return str(value)
+
+  @staticmethod
+  def from_json(value: typing.Any) -> typing.Any:
+    return str(value)
+
 class Clip(ParameterContainer):
   """Metadata for a camera clip
   """
-  duration: numbers.Rational = Duration()
-  fps: numbers.Rational = FPS()
-  active_sensor_physical_dimensions: IntegerDimensions = ActiveSensorPhysicalDimensions()
-  active_sensor_pixel_dimensions: IntegerDimensions = ActiveSensorPixelDimensions()
-
-  #
-  # Lens serial number
-  #
-
-  def set_lens_serial_number(self, serial_number : typing.Optional[str]):
-    if serial_number is not None and not isinstance(serial_number, str):
-      raise TypeError("The lens serial number must be a string")
-    self._lens_serial_number = serial_number
-
-  def get_lens_serial_number(self) -> typing.Optional[str]:
-    return self._lens_serial_number
-
-  #
-  # ISO
-  #
-
-  def set_iso(self, iso : typing.Optional[numbers.Integral]):
-    if iso is not None and not (isinstance(iso, numbers.Integral) and iso > 0):
-      raise TypeError("ISO must be an integral number larger than 0")
-    self._iso = iso
-
-  def get_iso(self) -> typing.Optional[numbers.Integral]:
-    return self._iso
-
-  #
-  # White balance
-  #
-
-  def set_white_balance(self, white_balance : typing.Optional[numbers.Integral]):
-    """White balance of the camera expressed as an integer in units of degrees kelvin.
-    """
-    if white_balance is not None and not (isinstance(white_balance, numbers.Integral) and white_balance > 0):
-      raise TypeError("White balance must be an integral number larger than 0")
-    self._white_balance = white_balance
-
-  def get_white_balance(self) -> typing.Optional[numbers.Integral]:
-    return self._white_balance
+  duration: typing.Optional[numbers.Rational] = Duration()
+  fps: typing.Optional[numbers.Rational] = FPS()
+  active_sensor_physical_dimensions: typing.Optional[IntegerDimensions] = ActiveSensorPhysicalDimensions()
+  active_sensor_pixel_dimensions: typing.Optional[IntegerDimensions] = ActiveSensorPixelDimensions()
+  lens_serial_number: typing.Optional[str] = LensSerialNumber()
+  white_balance: typing.Optional[numbers.Integral] = WhiteBalance()
+  iso: typing.Optional[numbers.Integral] = ISO()
 
   #
   # t-number
@@ -238,9 +257,6 @@ class Clip(ParameterContainer):
   #
 
   def __init__(self) -> None:
-    self._iso = None
-    self._lens_serial_number = None
-    self._white_balance = None
     self._focal_length = tuple()
     self._focal_position = tuple()
     self._t_number = tuple()

--- a/src/main/python/camdkit/model.py
+++ b/src/main/python/camdkit/model.py
@@ -41,7 +41,7 @@ class IntegerDimensions:
 class ActiveSensorPixelDimensions(Parameter):
   "Height and width in pixels of the active area of the camera sensor"
   
-  canonical_name = "active_sensor_pixels_dimensions"
+  canonical_name = "active_sensor_pixel_dimensions"
 
   @staticmethod
   def validate(value) -> bool:
@@ -58,7 +58,7 @@ class ActiveSensorPixelDimensions(Parameter):
 
   @staticmethod
   def to_json(value: typing.Any) -> typing.Any:
-    return value.asdict()
+    return dataclasses.asdict(value)
 
   @staticmethod
   def from_json(value: typing.Any) -> typing.Any:
@@ -84,7 +84,7 @@ class ActiveSensorPhysicalDimensions(Parameter):
 
   @staticmethod
   def to_json(value: typing.Any) -> typing.Any:
-    return value.asdict()
+    return dataclasses.asdict(value)
 
   @staticmethod
   def from_json(value: typing.Any) -> typing.Any:
@@ -135,7 +135,7 @@ class ISO(Parameter):
 
   @staticmethod
   def to_json(value: typing.Any) -> typing.Any:
-    return str(value)
+    return value
 
   @staticmethod
   def from_json(value: typing.Any) -> typing.Any:
@@ -153,7 +153,7 @@ class WhiteBalance(Parameter):
 
   @staticmethod
   def to_json(value: typing.Any) -> typing.Any:
-    return str(value)
+    return value
 
   @staticmethod
   def from_json(value: typing.Any) -> typing.Any:
@@ -187,6 +187,27 @@ class TNumber(Parameter):
   def validate(value) -> bool:
     if value is None:
       return True
+
+    return isinstance(value, tuple) and all(isinstance(s, numbers.Integral) and s > 0 for s in value)
+
+  @staticmethod
+  def to_json(value: typing.Any) -> typing.Any:
+    return value
+
+  @staticmethod
+  def from_json(value: typing.Any) -> typing.Any:
+    return tuple(value)
+
+
+class FocalLength(Parameter):
+  """Focal length of the lens in whole millimeters"""
+
+  canonical_name = "focal_length"
+
+  @staticmethod
+  def validate(value) -> bool:
+    if value is None:
+      return True
       
     return isinstance(value, tuple) and all(isinstance(s, numbers.Integral) and s > 0 for s in value)
 
@@ -198,8 +219,51 @@ class TNumber(Parameter):
   def from_json(value: typing.Any) -> typing.Any:
     return tuple(value)
 
+
+class FocalPosition(Parameter):
+  """Focus distance/position of the lens in whole millimeters"""
+
+  canonical_name = "focal_position"
+
+  @staticmethod
+  def validate(value) -> bool:
+    if value is None:
+      return True
+      
+    return isinstance(value, tuple) and all(isinstance(s, numbers.Integral) and s > 0 for s in value)
+
+  @staticmethod
+  def to_json(value: typing.Any) -> typing.Any:
+    return value
+
+  @staticmethod
+  def from_json(value: typing.Any) -> typing.Any:
+    return tuple(value)
+
+
+class EntrancePupilPosition(Parameter):
+  """Entrance pupil of the lens in fractional millimeters"""
+
+  canonical_name = "entrance_pupil_position"
+
+  @staticmethod
+  def validate(value) -> bool:
+    if value is None:
+      return True
+      
+    return isinstance(value, tuple) and all(isinstance(s, numbers.Rational) and s > 0 for s in value)
+
+  @staticmethod
+  def to_json(value: typing.Any) -> typing.Any:
+    return tuple(map(str, value))
+
+  @staticmethod
+  def from_json(value: typing.Any) -> typing.Any:
+    return tuple(map(Fraction, value))
+
+
 class Clip(ParameterContainer):
-  """Metadata for a camera clip
+  """Metadata for a camera clip.
   """
   duration: typing.Optional[numbers.Rational] = Duration()
   fps: typing.Optional[numbers.Rational] = FPS()
@@ -209,61 +273,6 @@ class Clip(ParameterContainer):
   white_balance: typing.Optional[numbers.Integral] = WhiteBalance()
   iso: typing.Optional[numbers.Integral] = ISO()
   t_number: typing.Optional[typing.Tuple[numbers.Integral]] = TNumber()
-
-
-  #
-  # Focal length
-  #
-
-  def set_focal_length(self, samples: typing.Iterable[numbers.Integral]):
-    focal_length = tuple(samples)
-
-    if not all(isinstance(s, numbers.Integral) and s > 0 for s in focal_length):
-      raise TypeError("Each sample must be an integer larger than 0 in units of millimeter.")
-
-    self._focal_length = focal_length
-
-  def get_focal_length(self) -> typing.Tuple[numbers.Integral]:
-    return self._focal_length
-
-
-  #
-  # Focal position
-  #
-
-  def set_focal_position(self, samples: typing.Iterable[numbers.Integral]):
-    focal_position = tuple(samples)
-
-    if not all(isinstance(s, numbers.Integral) and s > 0 for s in focal_position):
-      raise TypeError("Each sample must be an integer larger than 0 in units of millimeter.")
-
-    self._focal_position = focal_position
-
-  def get_focal_position(self) -> typing.Tuple[numbers.Integral]:
-    return self._focal_position
-
-
-  #
-  # Entrance Pupil Position
-  #
-
-  def set_entrance_pupil_position(self, samples: typing.Iterable[numbers.Rational]):
-    entrance_pupil_position = tuple(samples)
-
-    if not all(isinstance(s, numbers.Rational) for s in entrance_pupil_position):
-      raise TypeError("Each sample must be a rational number in units of millimeter.")
-
-    self._entrance_pupil_position = entrance_pupil_position
-
-  def get_entrance_pupil_position(self) -> typing.Tuple[numbers.Rational]:
-    return self._entrance_pupil_position
-
-  #
-  # constructor
-  #
-
-  def __init__(self) -> None:
-    self._focal_length = tuple()
-    self._focal_position = tuple()
-    self._entrance_pupil_position = tuple()
-
+  focal_length: typing.Optional[typing.Tuple[numbers.Integral]] = FocalLength()
+  focal_position: typing.Optional[typing.Tuple[numbers.Integral]] = FocalPosition()
+  entrance_pupil_position: typing.Optional[typing.Tuple[numbers.Rational]] = EntrancePupilPosition()

--- a/src/main/python/camdkit/model.py
+++ b/src/main/python/camdkit/model.py
@@ -177,6 +177,27 @@ class LensSerialNumber(Parameter):
   def from_json(value: typing.Any) -> typing.Any:
     return str(value)
 
+
+class TNumber(Parameter):
+  """Thousandths of the t-number of the lens as positive integer"""
+
+  canonical_name = "t_number"
+
+  @staticmethod
+  def validate(value) -> bool:
+    if value is None:
+      return True
+      
+    return isinstance(value, tuple) and all(isinstance(s, numbers.Integral) and s > 0 for s in value)
+
+  @staticmethod
+  def to_json(value: typing.Any) -> typing.Any:
+    return value
+
+  @staticmethod
+  def from_json(value: typing.Any) -> typing.Any:
+    return tuple(value)
+
 class Clip(ParameterContainer):
   """Metadata for a camera clip
   """
@@ -187,23 +208,8 @@ class Clip(ParameterContainer):
   lens_serial_number: typing.Optional[str] = LensSerialNumber()
   white_balance: typing.Optional[numbers.Integral] = WhiteBalance()
   iso: typing.Optional[numbers.Integral] = ISO()
+  t_number: typing.Optional[typing.Tuple[numbers.Integral]] = TNumber()
 
-  #
-  # t-number
-  #
-
-  def set_t_number(self, samples: typing.Iterable[numbers.Integral]):
-    """T-number of the lens (thousandth)
-    """
-    t_number = tuple(samples)
-
-    if not all(isinstance(s, numbers.Integral) and s > 0 for s in t_number):
-      raise TypeError("Each t-number sample must be an integer larger than 0.")
-
-    self._t_number = t_number
-
-  def get_t_number(self) -> typing.Tuple[numbers.Integral]:
-    return self._t_number
 
   #
   # Focal length
@@ -259,6 +265,5 @@ class Clip(ParameterContainer):
   def __init__(self) -> None:
     self._focal_length = tuple()
     self._focal_position = tuple()
-    self._t_number = tuple()
     self._entrance_pupil_position = tuple()
 

--- a/src/main/python/camdkit/model.py
+++ b/src/main/python/camdkit/model.py
@@ -104,7 +104,7 @@ class ParameterContainer:
       def _gen_setter(f):
         def setter(self, value):
           if not self._params[f].validate(value):
-            raise TypeError
+            raise ValueError
           self._values[f] = value
         return setter
 
@@ -145,27 +145,28 @@ class Duration(Parameter):
   def from_json(value: typing.Any) -> typing.Any:
     return Fraction(value)
 
+class FPS(Parameter):
+  """Frame frate in frames per second (fps)"""
+
+  canonical_name = "fps"
+
+  @staticmethod
+  def validate(value) -> bool:
+    return value is None or (isinstance(value, numbers.Rational) and value > 0)
+
+  @staticmethod
+  def to_json(value: typing.Any) -> typing.Any:
+    return str(value)
+
+  @staticmethod
+  def from_json(value: typing.Any) -> typing.Any:
+    return Fraction(value)
+
 class Clip(ParameterContainer):
   """Metadata for a camera clip
   """
-  duration : numbers.Rational = Duration()
-
-  #
-  # fps
-  #
-
-  def get_fps(self) -> typing.Optional[numbers.Rational]:
-    return self._fps
-
-  def set_fps(self, fps: typing.Optional[numbers.Rational]):
-    if fps is not None:
-      if not isinstance(fps, numbers.Rational):
-        raise TypeError("Must be a rational")
-
-      if fps <= 0:
-        raise ValueError("Must be a positive number")
-
-    self._fps = fps
+  duration: numbers.Rational = Duration()
+  fps: numbers.Rational = FPS()
 
   #
   # Sensor physical dimensions

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -57,15 +57,13 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
 
   clip.set_white_balance(int(clip_metadata["Kelvin"]))
 
-  clip.set_active_sensor_pixel_dimensions(
-    camdkit.model.SensorPixelDimensions(
-      width=int(clip_metadata["Frame Width"]),
-      height=int(clip_metadata["Frame Height"])
-    )
+  clip.active_sensor_pixel_dimensions = camdkit.model.IntegerDimensions(
+    width=int(clip_metadata["Frame Width"]),
+    height=int(clip_metadata["Frame Height"])
   )
 
   pixel_pitch = _LENS_NAME_PIXEL_PITCH_MAP[clip_metadata["Sensor Name"]]
-  pix_dims = clip.get_active_sensor_pixel_dimensions()
+  pix_dims = clip.active_sensor_pixel_dimensions
   clip.active_sensor_physical_dimensions = camdkit.model.IntegerDimensions(
     width=round(pix_dims.width * pixel_pitch),
     height=round(pix_dims.height * pixel_pitch)

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -89,6 +89,6 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
 
   clip.set_entrance_pupil_position(m.entrance_pupil_position for m in cooke_metadata)
 
-  clip.set_t_number(m.aperture_value * 10 for m in cooke_metadata)
+  clip.t_number = tuple(m.aperture_value * 10 for m in cooke_metadata)
 
   return clip

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -81,7 +81,7 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
   if len(csv_data) != n_frames:
     raise ValueError(f"Inconsistent frame count between header {n_frames} and frame {len(csv_data)} files")
 
-  clip.set_duration(len(csv_data)/Fraction(clip_metadata["FPS"]))
+  clip.duration = len(csv_data)/Fraction(clip_metadata["FPS"])
 
   clip.set_fps(Fraction(clip_metadata["FPS"]))
 

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -51,11 +51,11 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
   clip_metadata = next(csv.DictReader(meta_3_file))
   clip = camdkit.model.Clip()
 
-  clip.set_iso(int(clip_metadata['ISO']))
+  clip.iso = int(clip_metadata['ISO'])
 
-  clip.set_lens_serial_number(clip_metadata["Lens Serial Number"])
+  clip.lens_serial_number = clip_metadata["Lens Serial Number"]
 
-  clip.set_white_balance(int(clip_metadata["Kelvin"]))
+  clip.white_balance = int(clip_metadata["Kelvin"])
 
   clip.active_sensor_pixel_dimensions = camdkit.model.IntegerDimensions(
     width=int(clip_metadata["Frame Width"]),

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -83,7 +83,7 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
 
   clip.duration = len(csv_data)/Fraction(clip_metadata["FPS"])
 
-  clip.set_fps(Fraction(clip_metadata["FPS"]))
+  clip.fps = Fraction(clip_metadata["FPS"])
 
   clip.set_focal_length(tuple(int(m["Focal Length"]) * 1000 for m in csv_data))
 

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -81,13 +81,13 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
 
   clip.fps = Fraction(clip_metadata["FPS"])
 
-  clip.set_focal_length(tuple(int(m["Focal Length"]) * 1000 for m in csv_data))
+  clip.focal_length = tuple(int(m["Focal Length"]) * 1000 for m in csv_data)
 
-  clip.set_focal_position(tuple(int(m["Focus Distance"]) * 1000 for m in csv_data))
+  clip.focal_position = tuple(int(m["Focus Distance"]) * 1000 for m in csv_data)
 
   cooke_metadata = tuple(cooke.from_binary_string(bytes(int(i, 16) for i in m["Cooke Metadata"].split("/"))) for m in csv_data)
 
-  clip.set_entrance_pupil_position(m.entrance_pupil_position for m in cooke_metadata)
+  clip.entrance_pupil_position = tuple(m.entrance_pupil_position for m in cooke_metadata)
 
   clip.t_number = tuple(m.aperture_value * 10 for m in cooke_metadata)
 

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -66,11 +66,9 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
 
   pixel_pitch = _LENS_NAME_PIXEL_PITCH_MAP[clip_metadata["Sensor Name"]]
   pix_dims = clip.get_active_sensor_pixel_dimensions()
-  clip.set_active_sensor_physical_dimensions(
-    camdkit.model.SensorPhysicalDimensions(
-      width=round(pix_dims.width * pixel_pitch),
-      height=round(pix_dims.height * pixel_pitch)
-    )
+  clip.active_sensor_physical_dimensions = camdkit.model.IntegerDimensions(
+    width=round(pix_dims.width * pixel_pitch),
+    height=round(pix_dims.height * pixel_pitch)
   )
 
   # read frame metadata

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -164,11 +164,11 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
 
   clip.duration = len(csv_data)/clip_fps
 
-  clip.set_focal_length(tuple(int(m["Focal Length (mm)"]) for m in csv_data))
+  clip.focal_length = tuple(int(m["Focal Length (mm)"]) for m in csv_data)
 
-  clip.set_focal_position(tuple(round(float(m["Focus Distance (ft)"]) * 12 * 25.4) for m in csv_data))
+  clip.focal_position = tuple(round(float(m["Focus Distance (ft)"]) * 12 * 25.4) for m in csv_data)
 
-  # TODO: clip.set_entrance_pupil_position()
+  # TODO: clip.entrance_pupil_position
 
   clip.t_number = tuple(round(t_number_from_frac_stop(m["Aperture"]) * 1000) for m in csv_data)
 

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -164,7 +164,7 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
   if len(csv_data) != n_frames:
     raise ValueError(f"Inconsistent frame count between header {n_frames} and frame {len(csv_data)} files")
 
-  clip.set_duration(len(csv_data)/clip_fps)
+  clip.duration = len(csv_data)/clip_fps
 
   clip.set_focal_length(tuple(int(m["Focal Length (mm)"]) for m in csv_data))
 

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -151,12 +151,10 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
 
   pixel_pitch = 22800 / 3840 # page 5 of "VENICE v6 Ops.pdf"
   pix_dims = clip.get_active_sensor_pixel_dimensions()
-  clip.set_active_sensor_physical_dimensions(
-    camdkit.model.SensorPhysicalDimensions(
-      width=round(pix_dims.width * pixel_pitch),
-      height=round(pix_dims.height * pixel_pitch)
-    )
-  )
+  clip.active_sensor_physical_dimensions = camdkit.model.IntegerDimensions(
+        width=round(pix_dims.width * pixel_pitch),
+        height=round(pix_dims.height * pixel_pitch)
+      )
 
   # read frame metadata
   csv_data = list(csv.DictReader(dynamic_file))

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -170,6 +170,6 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
 
   # TODO: clip.set_entrance_pupil_position()
 
-  clip.set_t_number(tuple(round(t_number_from_frac_stop(m["Aperture"]) * 1000) for m in csv_data))
+  clip.t_number = tuple(round(t_number_from_frac_stop(m["Aperture"]) * 1000) for m in csv_data)
 
   return clip

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -129,11 +129,11 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
 
   clip_metadata = ET.parse(static_file)
 
-  clip.set_iso(int_or_none(find_value(clip_metadata, "ISOSensitivity")))
+  clip.iso = int_or_none(find_value(clip_metadata, "ISOSensitivity"))
 
-  clip.set_lens_serial_number(find_value(clip_metadata, "LensAttributes"))
+  clip.lens_serial_number = find_value(clip_metadata, "LensAttributes")
 
-  clip.set_white_balance(int_or_none(find_value(clip_metadata, "WhiteBalance")))
+  clip.white_balance = int_or_none(find_value(clip_metadata, "WhiteBalance"))
 
   clip.active_sensor_pixel_dimensions = find_px_dims(clip_metadata)
 

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -142,7 +142,7 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
   if clip_fps is None:
     raise ValueError("No valid fps found")
 
-  clip.set_fps(clip_fps)
+  clip.fps = clip_fps
 
   n_frames = find_duration(clip_metadata)
 

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -85,7 +85,7 @@ def find_duration(doc: ET.ElementTree) -> typing.Optional[int]:
   except TypeError:
     return None
 
-def find_px_dims(doc: ET.ElementTree) -> typing.Optional[camdkit.model.SensorPixelDimensions]:
+def find_px_dims(doc: ET.ElementTree) -> typing.Optional[camdkit.model.IntegerDimensions]:
   try:
     elem = doc.find(".//nrt:VideoLayout" , namespaces=NS_PREFIXES)
     
@@ -96,7 +96,7 @@ def find_px_dims(doc: ET.ElementTree) -> typing.Optional[camdkit.model.SensorPix
 
     v_pixels = int(elem.get("pixel"))
 
-    return camdkit.model.SensorPixelDimensions(height=h_pixels, width=v_pixels)
+    return camdkit.model.IntegerDimensions(height=h_pixels, width=v_pixels)
 
   except TypeError:
     return None
@@ -135,7 +135,7 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
 
   clip.set_white_balance(int_or_none(find_value(clip_metadata, "WhiteBalance")))
 
-  clip.set_active_sensor_pixel_dimensions(find_px_dims(clip_metadata))
+  clip.active_sensor_pixel_dimensions = find_px_dims(clip_metadata)
 
   clip_fps = find_fps(clip_metadata)
 
@@ -150,7 +150,7 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
     raise ValueError("No valid duration found")
 
   pixel_pitch = 22800 / 3840 # page 5 of "VENICE v6 Ops.pdf"
-  pix_dims = clip.get_active_sensor_pixel_dimensions()
+  pix_dims = clip.active_sensor_pixel_dimensions
   clip.active_sensor_physical_dimensions = camdkit.model.IntegerDimensions(
         width=round(pix_dims.width * pixel_pitch),
         height=round(pix_dims.height * pixel_pitch)

--- a/src/test/python/test_arri_reader.py
+++ b/src/test/python/test_arri_reader.py
@@ -36,7 +36,7 @@ class ARRIReaderTest(unittest.TestCase):
   def test_reader(self):
     clip = camdkit.arri.reader.to_clip("src/test/resources/arri/B001C001_180327_R1ZA.mov.csv")
 
-    self.assertEqual(clip.get_iso(), 400)
+    self.assertEqual(clip.iso, 400)
 
     self.assertEqual(
       clip.active_sensor_pixel_dimensions,
@@ -48,7 +48,7 @@ class ARRIReaderTest(unittest.TestCase):
       camdkit.model.IntegerDimensions(width=316800, height=178200)
     )
 
-    self.assertEqual(clip.get_lens_serial_number(), "2")
+    self.assertEqual(clip.lens_serial_number, "2")
 
     self.assertEqual(clip.fps, 24)
 
@@ -56,7 +56,7 @@ class ARRIReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.get_focal_position()[0], 4812)
 
-    self.assertEqual(clip.get_white_balance(), 3200)
+    self.assertEqual(clip.white_balance, 3200)
     
     self.assertEqual(clip.get_t_number()[0], 1782)
 

--- a/src/test/python/test_arri_reader.py
+++ b/src/test/python/test_arri_reader.py
@@ -45,7 +45,7 @@ class ARRIReaderTest(unittest.TestCase):
 
     self.assertEqual(
       clip.active_sensor_physical_dimensions,
-      camdkit.model.SensorPhysicalDimensions(width=316800, height=178200)
+      camdkit.model.IntegerDimensions(width=316800, height=178200)
     )
 
     self.assertEqual(clip.get_lens_serial_number(), "2")

--- a/src/test/python/test_arri_reader.py
+++ b/src/test/python/test_arri_reader.py
@@ -52,9 +52,9 @@ class ARRIReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.fps, 24)
 
-    self.assertEqual(clip.get_focal_length()[0], 40000)
+    self.assertEqual(clip.focal_length[0], 40000)
 
-    self.assertEqual(clip.get_focal_position()[0], 4812)
+    self.assertEqual(clip.focal_position[0], 4812)
 
     self.assertEqual(clip.white_balance, 3200)
     

--- a/src/test/python/test_arri_reader.py
+++ b/src/test/python/test_arri_reader.py
@@ -50,7 +50,7 @@ class ARRIReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.get_lens_serial_number(), "2")
 
-    self.assertEqual(clip.get_fps(), 24)
+    self.assertEqual(clip.fps, 24)
 
     self.assertEqual(clip.get_focal_length()[0], 40000)
 

--- a/src/test/python/test_arri_reader.py
+++ b/src/test/python/test_arri_reader.py
@@ -44,7 +44,7 @@ class ARRIReaderTest(unittest.TestCase):
     )
 
     self.assertEqual(
-      clip.get_active_sensor_physical_dimensions(),
+      clip.active_sensor_physical_dimensions,
       camdkit.model.SensorPhysicalDimensions(width=316800, height=178200)
     )
 

--- a/src/test/python/test_arri_reader.py
+++ b/src/test/python/test_arri_reader.py
@@ -58,7 +58,7 @@ class ARRIReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.white_balance, 3200)
     
-    self.assertEqual(clip.get_t_number()[0], 1782)
+    self.assertEqual(clip.t_number[0], 1782)
 
   def test_linear_iris_value(self):
     self.assertEqual(round(camdkit.arri.reader.t_number_from_linear_iris_value(6000) * 1000), 5657)

--- a/src/test/python/test_arri_reader.py
+++ b/src/test/python/test_arri_reader.py
@@ -39,8 +39,8 @@ class ARRIReaderTest(unittest.TestCase):
     self.assertEqual(clip.get_iso(), 400)
 
     self.assertEqual(
-      clip.get_active_sensor_pixel_dimensions(),
-      camdkit.model.SensorPixelDimensions(width=1920, height=1080)
+      clip.active_sensor_pixel_dimensions,
+      camdkit.model.IntegerDimensions(width=1920, height=1080)
     )
 
     self.assertEqual(

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -44,7 +44,7 @@ class ModelTest(unittest.TestCase):
   def test_serialize(self):
     clip = camdkit.model.Clip()
     clip.duration = 3
-    clip.set_iso(13)
+    clip.iso = 13
     clip.set_focal_length([2, 4])
 
     d = clip.to_json()
@@ -91,30 +91,30 @@ class ModelTest(unittest.TestCase):
   def test_lens_serial_number(self):
     clip = camdkit.model.Clip()
 
-    self.assertIsNone(clip.get_lens_serial_number())
+    self.assertIsNone(clip.lens_serial_number)
 
-    with self.assertRaises(TypeError):
-      clip.set_lens_serial_number(0.7)
+    with self.assertRaises(ValueError):
+      clip.lens_serial_number = 0.7
 
     value = "1231231321"
 
-    clip.set_lens_serial_number(value)
+    clip.lens_serial_number = value
 
-    self.assertEqual(clip.get_lens_serial_number(), value)
+    self.assertEqual(clip.lens_serial_number, value)
 
   def test_iso(self):
     clip = camdkit.model.Clip()
 
-    self.assertIsNone(clip.get_iso())
+    self.assertIsNone(clip.iso)
 
-    with self.assertRaises(TypeError):
-      clip.set_iso(0.7)
+    with self.assertRaises(ValueError):
+      clip.iso = 0.7
 
     value = 200
 
-    clip.set_iso(value)
+    clip.iso = value
 
-    self.assertEqual(clip.get_iso(), value)
+    self.assertEqual(clip.iso, value)
 
   def test_fps(self):
     clip = camdkit.model.Clip()
@@ -193,13 +193,13 @@ class ModelTest(unittest.TestCase):
   def test_white_balance(self):
     clip = camdkit.model.Clip()
 
-    self.assertIsNone(clip.get_white_balance())
+    self.assertIsNone(clip.white_balance)
 
-    with self.assertRaises(TypeError):
-      clip.set_white_balance(0.5)
+    with self.assertRaises(ValueError):
+      clip.white_balance = 0.5
 
     value = 6500
 
-    clip.set_white_balance(value)
+    clip.white_balance = value
 
-    self.assertEqual(clip.get_white_balance(), value)
+    self.assertEqual(clip.white_balance, value)

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -137,16 +137,16 @@ class ModelTest(unittest.TestCase):
   def test_t_number(self):
     clip = camdkit.model.Clip()
 
-    self.assertTupleEqual(clip.get_t_number(), tuple())
+    self.assertEqual(clip.t_number, None)
 
-    with self.assertRaises(TypeError):
-      clip.set_t_number([0.7])
+    with self.assertRaises(ValueError):
+      clip.t_number = [0.7]
 
     value = (4000, 8000)
 
-    clip.set_t_number(value)
+    clip.t_number = value
 
-    self.assertTupleEqual(clip.get_t_number(), value)
+    self.assertTupleEqual(clip.t_number, value)
 
   def test_focal_length(self):
     clip = camdkit.model.Clip()

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -35,35 +35,35 @@ class ModelTest(unittest.TestCase):
   def test_duration(self):
     clip = camdkit.model.Clip()
 
-    self.assertIsNone(clip.get_duration())
+    self.assertIsNone(clip.duration)
 
-    clip.set_duration(3)
+    clip.duration = 3
 
-    self.assertEqual(clip.get_duration(), 3)
+    self.assertEqual(clip.duration, 3)
 
   def test_serialize(self):
     clip = camdkit.model.Clip()
-    clip.set_duration(3)
+    clip.duration = 3
     clip.set_iso(13)
     clip.set_focal_length([2, 4])
 
-    d = clip.serialize()
+    d = clip.to_json()
 
     self.assertEqual(d["focal_length"], (2, 4))
     self.assertEqual(d["duration"], "3")
     self.assertEqual(d["iso"], 13)
 
-  def test_duration(self):
+  def test_duration_fraction(self):
     clip = camdkit.model.Clip()
 
-    self.assertIsNone(clip.get_duration())
+    self.assertIsNone(clip.duration)
 
-    clip.set_duration(Fraction(6, 7))
+    clip.duration = Fraction(6, 7)
 
     with self.assertRaises(TypeError):
-      clip.set_duration(0.7)
+      clip.duration = 0.7
 
-    self.assertEqual(clip.get_duration(), Fraction(6, 7))
+    self.assertEqual(clip.duration, Fraction(6, 7))
   
   def test_active_sensor_physical_dimensions(self):
     clip = camdkit.model.Clip()

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -80,13 +80,13 @@ class ModelTest(unittest.TestCase):
   def test_active_sensor_pixel_dimensions(self):
     clip = camdkit.model.Clip()
 
-    self.assertIsNone(clip.get_active_sensor_pixel_dimensions())
+    self.assertIsNone(clip.active_sensor_pixel_dimensions)
 
-    dims = camdkit.model.SensorPixelDimensions(4, 5)
+    dims = camdkit.model.IntegerDimensions(4, 5)
 
-    clip.set_active_sensor_pixel_dimensions(dims)
+    clip.active_sensor_pixel_dimensions = dims
 
-    self.assertEqual(clip.get_active_sensor_pixel_dimensions(), dims)
+    self.assertEqual(clip.active_sensor_pixel_dimensions, dims)
 
   def test_lens_serial_number(self):
     clip = camdkit.model.Clip()

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -68,13 +68,13 @@ class ModelTest(unittest.TestCase):
   def test_active_sensor_physical_dimensions(self):
     clip = camdkit.model.Clip()
 
-    self.assertIsNone(clip.get_active_sensor_physical_dimensions())
+    self.assertIsNone(clip.active_sensor_physical_dimensions)
 
-    dims = camdkit.model.SensorPhysicalDimensions(4, 5)
+    dims = camdkit.model.IntegerDimensions(4, 5)
 
-    clip.set_active_sensor_physical_dimensions(dims)
+    clip.active_sensor_physical_dimensions = dims
 
-    self.assertEqual(clip.get_active_sensor_physical_dimensions(), dims)
+    self.assertEqual(clip.active_sensor_physical_dimensions, dims)
 
 
   def test_active_sensor_pixel_dimensions(self):

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -60,7 +60,7 @@ class ModelTest(unittest.TestCase):
 
     clip.duration = Fraction(6, 7)
 
-    with self.assertRaises(TypeError):
+    with self.assertRaises(ValueError):
       clip.duration = 0.7
 
     self.assertEqual(clip.duration, Fraction(6, 7))
@@ -119,19 +119,19 @@ class ModelTest(unittest.TestCase):
   def test_fps(self):
     clip = camdkit.model.Clip()
 
-    self.assertIsNone(clip.get_fps())
-
-    with self.assertRaises(TypeError):
-      clip.set_fps(0.7)
+    self.assertIsNone(clip.fps)
 
     with self.assertRaises(ValueError):
-      clip.set_fps(-24)
+      clip.fps = 0.7
+
+    with self.assertRaises(ValueError):
+      clip.fps = -24
 
     value = Fraction(24000, 1001)
 
-    clip.set_fps(value)
+    clip.fps = value
 
-    self.assertEqual(clip.get_fps(), value)
+    self.assertEqual(clip.fps, value)
 
 
   def test_t_number(self):

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -43,15 +43,37 @@ class ModelTest(unittest.TestCase):
 
   def test_serialize(self):
     clip = camdkit.model.Clip()
+
     clip.duration = 3
+    clip.fps = Fraction(24000, 1001)
+    clip.active_sensor_physical_dimensions = camdkit.model.IntegerDimensions(width=640, height=480)
+    clip.active_sensor_pixel_dimensions = camdkit.model.IntegerDimensions(width=640, height=480)
+    clip.lens_serial_number = "123456789"
+    clip.white_balance = 7200
     clip.iso = 13
-    clip.set_focal_length([2, 4])
+    clip.t_number = (2, 4)
+    clip.focal_length = (2, 4)
+    clip.focal_position = (2, 4)
+    clip.entrance_pupil_position = (Fraction(1, 2), Fraction(13, 7))
 
     d = clip.to_json()
 
-    self.assertEqual(d["focal_length"], (2, 4))
     self.assertEqual(d["duration"], "3")
+    self.assertEqual(d["fps"], "24000/1001")
+    self.assertDictEqual(d["active_sensor_physical_dimensions"], {"height": 480, "width": 640})
+    self.assertDictEqual(d["active_sensor_pixel_dimensions"], {"height": 480, "width": 640})
+    self.assertEqual(d["lens_serial_number"], "123456789")
+    self.assertEqual(d["white_balance"], 7200)
     self.assertEqual(d["iso"], 13)
+    self.assertTupleEqual(d["t_number"], (2, 4))
+    self.assertTupleEqual(d["focal_length"], (2, 4))
+    self.assertTupleEqual(d["focal_position"], (2, 4))
+    self.assertTupleEqual(d["entrance_pupil_position"], ("1/2", "13/7"))
+
+    d_clip = camdkit.model.Clip()
+    d_clip.from_json(d)
+
+    self.assertDictEqual(d_clip._values, clip._values)
 
   def test_duration_fraction(self):
     clip = camdkit.model.Clip()
@@ -151,44 +173,44 @@ class ModelTest(unittest.TestCase):
   def test_focal_length(self):
     clip = camdkit.model.Clip()
 
-    self.assertTupleEqual(clip.get_focal_length(), tuple())
+    self.assertIsNone(clip.focal_length)
 
-    with self.assertRaises(TypeError):
-      clip.set_focal_length([Fraction(5,7)])
+    with self.assertRaises(ValueError):
+      clip.focal_length = [Fraction(5,7)]
 
     value = (100, 7)
 
-    clip.set_focal_length(value)
+    clip.focal_length = value
 
-    self.assertTupleEqual(clip.get_focal_length(), value)
+    self.assertTupleEqual(clip.focal_length, value)
 
   def test_focal_position(self):
     clip = camdkit.model.Clip()
 
-    self.assertTupleEqual(clip.get_focal_position(), tuple())
+    self.assertIsNone(clip.focal_position)
 
-    with self.assertRaises(TypeError):
-      clip.set_focal_position([Fraction(5,7)])
+    with self.assertRaises(ValueError):
+      clip.focal_position = [Fraction(5,7)]
 
     value = (100, 7)
 
-    clip.set_focal_position(value)
+    clip.focal_position = value
 
-    self.assertTupleEqual(clip.get_focal_position(), value)
+    self.assertTupleEqual(clip.focal_position, value)
 
   def test_entrance_pupil_position(self):
     clip = camdkit.model.Clip()
 
-    self.assertTupleEqual(clip.get_entrance_pupil_position(), tuple())
+    self.assertIsNone(clip.entrance_pupil_position)
 
-    with self.assertRaises(TypeError):
-      clip.set_focal_position([0.6])
+    with self.assertRaises(ValueError):
+      clip.focal_position = [0.6]
 
     value = (Fraction(5,7), 7)
 
-    clip.set_entrance_pupil_position(value)
+    clip.set_entrance_pupil_position = value
 
-    self.assertTupleEqual(clip.get_entrance_pupil_position(), value)
+    self.assertIsNone(clip.entrance_pupil_position, value)
 
   def test_white_balance(self):
     clip = camdkit.model.Clip()

--- a/src/test/python/test_red_reader.py
+++ b/src/test/python/test_red_reader.py
@@ -37,7 +37,7 @@ class REDReaderTest(unittest.TestCase):
       open("src/test/resources/red/A001_C066_0303LZ_001.frames.csv", "r", encoding="utf-8") as type_5_file:
       clip = camdkit.red.reader.to_clip(type_3_file, type_5_file)
 
-    self.assertEqual(clip.get_iso(), 250)
+    self.assertEqual(clip.iso, 250)
 
     self.assertEqual(clip.get_focal_length()[0], 40000)
 
@@ -47,9 +47,9 @@ class REDReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.fps, 24)
 
-    self.assertEqual(clip.get_lens_serial_number(), "G53599764")
+    self.assertEqual(clip.lens_serial_number, "G53599764")
 
-    self.assertEqual(clip.get_white_balance(), 5600)
+    self.assertEqual(clip.white_balance, 5600)
 
     self.assertEqual(
       clip.active_sensor_pixel_dimensions,
@@ -58,5 +58,5 @@ class REDReaderTest(unittest.TestCase):
 
     self.assertEqual(
       clip.active_sensor_physical_dimensions,
-      camdkit.model.SensorPhysicalDimensions(width=4096 * 5, height=2160 * 5)
+      camdkit.model.IntegerDimensions(width=4096 * 5, height=2160 * 5)
     )

--- a/src/test/python/test_red_reader.py
+++ b/src/test/python/test_red_reader.py
@@ -45,7 +45,7 @@ class REDReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.get_t_number()[0], 5600)
 
-    self.assertEqual(clip.get_fps(), 24)
+    self.assertEqual(clip.fps, 24)
 
     self.assertEqual(clip.get_lens_serial_number(), "G53599764")
 

--- a/src/test/python/test_red_reader.py
+++ b/src/test/python/test_red_reader.py
@@ -43,7 +43,7 @@ class REDReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.get_entrance_pupil_position()[0], 127)
 
-    self.assertEqual(clip.get_t_number()[0], 5600)
+    self.assertEqual(clip.t_number[0], 5600)
 
     self.assertEqual(clip.fps, 24)
 

--- a/src/test/python/test_red_reader.py
+++ b/src/test/python/test_red_reader.py
@@ -39,9 +39,9 @@ class REDReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.iso, 250)
 
-    self.assertEqual(clip.get_focal_length()[0], 40000)
+    self.assertEqual(clip.focal_length[0], 40000)
 
-    self.assertEqual(clip.get_entrance_pupil_position()[0], 127)
+    self.assertEqual(clip.entrance_pupil_position[0], 127)
 
     self.assertEqual(clip.t_number[0], 5600)
 

--- a/src/test/python/test_red_reader.py
+++ b/src/test/python/test_red_reader.py
@@ -52,8 +52,8 @@ class REDReaderTest(unittest.TestCase):
     self.assertEqual(clip.get_white_balance(), 5600)
 
     self.assertEqual(
-      clip.get_active_sensor_pixel_dimensions(),
-      camdkit.model.SensorPixelDimensions(width=4096, height=2160)
+      clip.active_sensor_pixel_dimensions,
+      camdkit.model.IntegerDimensions(width=4096, height=2160)
     )
 
     self.assertEqual(

--- a/src/test/python/test_red_reader.py
+++ b/src/test/python/test_red_reader.py
@@ -57,6 +57,6 @@ class REDReaderTest(unittest.TestCase):
     )
 
     self.assertEqual(
-      clip.get_active_sensor_physical_dimensions(),
+      clip.active_sensor_physical_dimensions,
       camdkit.model.SensorPhysicalDimensions(width=4096 * 5, height=2160 * 5)
     )

--- a/src/test/python/test_venice_reader.py
+++ b/src/test/python/test_venice_reader.py
@@ -44,7 +44,7 @@ class VenicReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.iso, 500)
 
-    self.assertEqual(clip.get_focal_length()[0], 32)
+    self.assertEqual(clip.focal_length[0], 32)
 
     self.assertEqual(clip.t_number[0], 2219)
 

--- a/src/test/python/test_venice_reader.py
+++ b/src/test/python/test_venice_reader.py
@@ -60,6 +60,6 @@ class VenicReaderTest(unittest.TestCase):
     )
 
     self.assertEqual(
-      clip.get_active_sensor_physical_dimensions(),
+      clip.active_sensor_physical_dimensions,
       camdkit.model.SensorPhysicalDimensions(width=round(5674 * 5.9375), height=round(3192 * 5.9375))
     )

--- a/src/test/python/test_venice_reader.py
+++ b/src/test/python/test_venice_reader.py
@@ -46,7 +46,7 @@ class VenicReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.get_focal_length()[0], 32)
 
-    self.assertEqual(clip.get_t_number()[0], 2219)
+    self.assertEqual(clip.t_number[0], 2219)
 
     self.assertEqual(clip.fps, 24)
 

--- a/src/test/python/test_venice_reader.py
+++ b/src/test/python/test_venice_reader.py
@@ -48,7 +48,7 @@ class VenicReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.get_t_number()[0], 2219)
 
-    self.assertEqual(clip.get_fps(), 24)
+    self.assertEqual(clip.fps, 24)
 
     self.assertEqual(clip.get_lens_serial_number(), "7032.0100")
 

--- a/src/test/python/test_venice_reader.py
+++ b/src/test/python/test_venice_reader.py
@@ -55,8 +55,8 @@ class VenicReaderTest(unittest.TestCase):
     self.assertEqual(clip.get_white_balance(), 4300)
 
     self.assertEqual(
-      clip.get_active_sensor_pixel_dimensions(),
-      camdkit.model.SensorPixelDimensions(width=5674, height=3192)
+      clip.active_sensor_pixel_dimensions,
+      camdkit.model.IntegerDimensions(width=5674, height=3192)
     )
 
     self.assertEqual(

--- a/src/test/python/test_venice_reader.py
+++ b/src/test/python/test_venice_reader.py
@@ -42,7 +42,7 @@ class VenicReaderTest(unittest.TestCase):
       open("src/test/resources/venice/D001C005_210716AG.csv", "r", encoding="utf-8") as dynamic_file:
       clip = camdkit.venice.reader.to_clip(static_file, dynamic_file)
 
-    self.assertEqual(clip.get_iso(), 500)
+    self.assertEqual(clip.iso, 500)
 
     self.assertEqual(clip.get_focal_length()[0], 32)
 
@@ -50,9 +50,9 @@ class VenicReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.fps, 24)
 
-    self.assertEqual(clip.get_lens_serial_number(), "7032.0100")
+    self.assertEqual(clip.lens_serial_number, "7032.0100")
 
-    self.assertEqual(clip.get_white_balance(), 4300)
+    self.assertEqual(clip.white_balance, 4300)
 
     self.assertEqual(
       clip.active_sensor_pixel_dimensions,
@@ -61,5 +61,5 @@ class VenicReaderTest(unittest.TestCase):
 
     self.assertEqual(
       clip.active_sensor_physical_dimensions,
-      camdkit.model.SensorPhysicalDimensions(width=round(5674 * 5.9375), height=round(3192 * 5.9375))
+      camdkit.model.IntegerDimensions(width=round(5674 * 5.9375), height=round(3192 * 5.9375))
     )


### PR DESCRIPTION
Each metadata parameter is defined in its own class in `camdkit.model`, e.g. `EntrancePupilPosition`.

Metadata parameter values can be set and retrieved from a `Clip` as an object variable, e.g. `clip.fps`, without the need for getters and setters.